### PR TITLE
(FIX) Fixes for the puppet-content-template template

### DIFF
--- a/puppet-content-template/content/content/README.md
+++ b/puppet-content-template/content/content/README.md
@@ -12,15 +12,15 @@ A PCT must contain a `pct-config.yml` in the root directory, alongside a `conten
 
 The `content` directory contains the files and folders required to produce the `project` or `item`.
 
-To mark a file as a template, use the `.tmpl` extension. Templated files can also use the global variable of `{{pct_name}}` to access the input from the `--name` cli argument.
+To mark a file as a template, use the `.tmpl` extension. Templated files can also use the global variable of {{"`{{.pct_name}}`"}} to access the input from the `--name` cli argument.
 
-> :memo: Folders within the `content` directory can also use the `{{pct_name}}` variable
+> :memo: Folders within the `content` directory can also use the {{"`{{.pct_name}}`"}} variable
 
 Example template file names:
 
 ``` bash
 myConfig.json.tmpl
-{{pct_name}}_spec.rb
+{{`{{.pct_name}}`}}_spec.rb
 ```
 
 > :memo: One, all or none of the files can be templated.

--- a/puppet-content-template/content/pct-config.yml.tmpl
+++ b/puppet-content-template/content/pct-config.yml.tmpl
@@ -2,6 +2,6 @@
 template:
   id: {{.pct_name}}
   type: project
-  display: {{ toTitleCase .pct_name}}
+  display: {{ toClassName .pct_name}}
   version: 0.1.0
   url: https://github.com/puppetlabs/pct-{{.pct_name}}


### PR DESCRIPTION
Was calling non-existent `toTitleCase` func. `toClassName` is
effectively the functionality we want, although the name may be a
bit confusing.

Fixed references to `{{pct_name}}` -> `{{.pct_name}}` and escaped
string literals where needed.