### PR TITLE
(GH-14) Fix puppet-control-repo id

### DIFF
--- a/puppet-control-repo/pct-config.yml
+++ b/puppet-control-repo/pct-config.yml
@@ -1,6 +1,6 @@
 ---
 template:
-  name: "puppet-control-repo"
+  id: "puppet-control-repo"
   type: "project"
   display: "Puppet Control Repo"
   version: 0.1.0


### PR DESCRIPTION
Correct the puppet-control-repo identifier to `id`
