### PR TITLE
(GH-18) Add author key to all configs

### DIFF
--- a/bolt-plan/pct-config.yml
+++ b/bolt-plan/pct-config.yml
@@ -1,6 +1,7 @@
 ---
 template:
   id: bolt-plan
+  author: puppetlabs
   type: item
   display: "Bolt Plan"
   version: 0.1.0

--- a/bolt-project/pct-config.yml
+++ b/bolt-project/pct-config.yml
@@ -1,6 +1,7 @@
 ---
 template:
   id: bolt-project
+  author: puppetlabs
   type: project
   display: Bolt Project
   version: 0.1.0

--- a/bolt-pwsh-task/pct-config.yml
+++ b/bolt-pwsh-task/pct-config.yml
@@ -1,6 +1,7 @@
 ---
 template:
   id: bolt-pwsh-task
+  author: puppetlabs
   type: item
   display: "Bolt PowerShell Task"
   version: 0.1.0

--- a/bolt-yaml-plan/pct-config.yml
+++ b/bolt-yaml-plan/pct-config.yml
@@ -1,6 +1,7 @@
 ---
 template:
   id: bolt-yaml-plan
+  author: puppetlabs
   type: item
   display: "Bolt YAML Plan"
   version: 0.1.0

--- a/editorconfig/pct-config.yml
+++ b/editorconfig/pct-config.yml
@@ -1,6 +1,7 @@
 ---
 template:
   id: editorconfig
+  author: puppetlabs
   type: item
   display: .editorconfig file
   version: 0.1.0

--- a/ghactions-spec-workflow-supported-puppet/pct-config.yml
+++ b/ghactions-spec-workflow-supported-puppet/pct-config.yml
@@ -1,11 +1,12 @@
 ---
 template:
   id: ghactions-spec-workflow-supported-puppet
+  author: puppetlabs
   type: item
   display: GHActions for Spec Tests with Supported Puppet Versions
   version: 0.1.0
   url: https://github.com/puppetlabs/baker-round
- 
+
 ghactions_spec:
   name: "Spec Tests"
   runs_on: 'ubuntu-latest'

--- a/git-attributes/pct-config.yml
+++ b/git-attributes/pct-config.yml
@@ -1,6 +1,7 @@
 ---
 template:
   id: git-attributes
+  author: puppetlabs
   type: item
   display: Puppet Git Attributes File
   version: 0.1.0

--- a/git-ignore/pct-config.yml
+++ b/git-ignore/pct-config.yml
@@ -1,6 +1,7 @@
 ---
 template:
   id: git-ignore
+  author: puppetlabs
   type: item
   display: Puppet Git Ignore File
   version: 0.1.0

--- a/puppet-class/pct-config.yml
+++ b/puppet-class/pct-config.yml
@@ -1,6 +1,7 @@
 ---
 template:
   id: puppet-class
+  author: puppetlabs
   type: item
   display: Puppet Class
   version: 0.1.0

--- a/puppet-content-template/pct-config.yml
+++ b/puppet-content-template/pct-config.yml
@@ -1,6 +1,7 @@
 ---
 template:
   id: puppet-content-template
+  author: puppetlabs
   type: project
   display: Puppet Content Template
   version: 0.1.0

--- a/puppet-control-repo/pct-config.yml
+++ b/puppet-control-repo/pct-config.yml
@@ -1,6 +1,7 @@
 ---
 template:
   id: "puppet-control-repo"
+  author: puppetlabs
   type: "project"
   display: "Puppet Control Repo"
   version: 0.1.0

--- a/puppet-defined-type/pct-config.yml
+++ b/puppet-defined-type/pct-config.yml
@@ -1,6 +1,7 @@
 ---
 template:
   id: puppet-defined-type
+  author: puppetlabs
   type: item
   display: "Puppet Defined Type"
   version: 0.1.0

--- a/puppet-fact/pct-config.yml
+++ b/puppet-fact/pct-config.yml
@@ -1,6 +1,7 @@
 ---
 template:
   id: puppet-fact
+  author: puppetlabs
   type: item
   display: Puppet Fact
   version: 0.1.0

--- a/puppet-module-base/pct-config.yml
+++ b/puppet-module-base/pct-config.yml
@@ -1,6 +1,7 @@
 ---
 template:
   id: puppet-module-base
+  author: puppetlabs
   type: project
   display: Puppet Module Base
   version: 0.1.0

--- a/rsapi-provider/pct-config.yml
+++ b/rsapi-provider/pct-config.yml
@@ -1,6 +1,7 @@
 ---
 template:
   id: rsapi-provider
+  author: puppetlabs
   display: Puppet Resource API Provider
   type: item
   version: 0.1.0


### PR DESCRIPTION
Prior to this commit, the PCT Config files for all templates were missing the author key. This is necessary to comply with the namespacing architecture for templates.

This commit adds the author key to every template in this repository with the value set to puppetlabs.

Resolves #18.