### PR TITLE
(GH-17) Add author to puppet-content-template

### DIFF
--- a/puppet-content-template/content/pct-config.yml.tmpl
+++ b/puppet-content-template/content/pct-config.yml.tmpl
@@ -1,6 +1,7 @@
 ---
 template:
   id: {{.pct_name}}
+  author: {{.puppet_content_template.author}}
   type: project
   display: {{ toClassName .pct_name}}
   version: 0.1.0

--- a/puppet-content-template/pct-config.yml
+++ b/puppet-content-template/pct-config.yml
@@ -5,3 +5,6 @@ template:
   display: Puppet Content Template
   version: 0.1.0
   url: https://github.com/puppetlabs/pct
+
+puppet_content_template:
+  author: <Replace with author id, e.g. 'puppetlabs'>


### PR DESCRIPTION
Prior to this commit, the `puppet-content-template` template did not scaffold the mandatory `author` key and value into the generated `pct-config.yml` file.

This commit ensures that it does, adding `author` as a parameter to the template with a default value instructing the template writer to replace it with their own author id.

Resolves #17.